### PR TITLE
FIX : nautilus background greyed

### DIFF
--- a/gtk-3.0/apps/gnome-applications.css
+++ b/gtk-3.0/apps/gnome-applications.css
@@ -81,7 +81,7 @@ WnckPager, WnckTasklist {
  * nautilus *
  ************/
 .nautilus-canvas-item {
-    border-radius: 2px;
+    border-radius: 0px;
 }
 
 .nautilus-desktop.nautilus-canvas-item {


### PR DESCRIPTION
border-radius > 0px makes nautilus background become @theme_bg_color (grey) instead of white.
