### PR TITLE
Fix LXDE panel window buttons' style

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -477,6 +477,11 @@ widget_class "*Applet*Tomboy*" style "murrine-panel"
 widget_class "*Applet*Netstatus*" style "murrine-panel"
 widget "*gdm-user-switch-menubar*" style "murrine-panel"
 
+# LXPanel (code based on Lubuntu-default theme's gtkrc file)
+widget "*.tclock.*" style "murrine-panel"
+widget "*.taskbar.*" style "murrine-panel"
+widget_class "*GtkBgbox*" style "murrine-panel"
+
 style "bold-panel-item" {
 	font_name = "Bold"
 


### PR DESCRIPTION
This patch add some code to Numix gtk-2.0 gtkrc file to apply correctly panel styles to LXDE panel. Fixes #147.
