### PR TITLE
Fix transparent tooltips in Firefox

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3210,8 +3210,18 @@ GtkColorButton.button {
     color: @theme_tooltip_fg_color;
 }
 
+.tooltip.background {
+    background-color: @theme_tooltip_bg_color;
+    background-clip: padding-box;
+}
+
+.tooltip.window-frame.csd {
+    background-color: transparent;
+}
+
 .tooltip * {
     background-color: transparent;
+    color: inherit;
 }
 
 /************


### PR DESCRIPTION
Fix #225
