### PR TITLE
adds support for unity-greeter

### DIFF
--- a/gtk-3.0/scss/_widgets.scss
+++ b/gtk-3.0/scss/_widgets.scss
@@ -25,7 +25,7 @@
 @import "widgets/view";
 @import "widgets/window";
 
-
+@import "apps/unity-greeter";
 @import "apps/gedit";
 @import "apps/nautilus";
 @import "apps/nemo";

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -3,70 +3,87 @@
  ***********************/
 
 @include exports("unity-greeter") {
-    .lightdm.menu {
-        background-image: none;
-        background-color: #00ff00;
-        border-color: #00ff00;
-        border-radius: 4px;
-        padding: 1px;
-        color: #00ff00;
-    }
 
-    .lightdm-combo .menu {
-        background-color: #00ff00;
-        border-radius: 0px;
-        padding: 0px;
-        color: #00ff00;
-    }
 
-    .lightdm.menu .menuitem *,
-    .lightdm.menu .menuitem.check:active,
-    .lightdm.menu .menuitem.radio:active {
-        color: #00ff00;
-    }
+.lightdm.menu {
+    background-image: none;
+    background-color: alpha($black, 0.6);
+    border-color: alpha($white, 0.2);
+    border-radius: 4px;
+    padding: 1px;
 
-    .lightdm.menubar {
-        background-image: none;
-        background-color: #00ff00;
-    }
+    color: $white;
+}
+
+.lightdm-combo .menu {
+    background-color: shade($dark_bg_color, 1.08);
+    border-radius: 0px;
+    padding: 0px;
+
+    color: $white;
+}
+
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
+    color: $white;
+}
+
+.lightdm.menubar {
+    background-image: none;
+    background-color: alpha(#00ff00, 0.5);
+}
+
 
     .lightdm-combo.combobox-entry .button,
     .lightdm-combo .cell,
     .lightdm-combo .button,
     .lightdm-combo .entry,
-    .lightdm.button,
-    .lightdm.entry {
+    
+    .lightdm.button{
         background-image: none;
-        background-color: alpha (black, 0.3);
-        border-color: alpha (white, 0.6);
+        background-color: alpha($black, 0.3);
+        border-color: alpha($white, 0.9);
         border-radius: 5px;
-        padding: 7px;
-        color: white;
+        padding: 5px;
+        color: $white;
+        }
+    .lightdm.button:hover {
+        background-image: none;
+        background-color: alpha($white, 0.3);
+        border-color: alpha($white, 0.6);
+        border-radius: 5px;
+        padding: 5px;
+        color: $white;
         text-shadow: none;
-    }
-
-    .lightdm.button,
-    .lightdm.button:hover,
+        }
     .lightdm.button:active,
     .lightdm.button:active:focused,
-    .lightdm.entry,
+    .lightdm.button:focused,
+
+    .lightdm.entry {
+        background-image: none;
+        background-color: alpha($black, 0.3);
+        border-color: alpha($white, 0.6);
+        border-radius: 5px;
+        padding: 7px;
+        color: $white;
+        text-shadow: none;
+    }
     .lightdm.entry:hover,
     .lightdm.entry:active,
     .lightdm.entry:active:focused {
         background-image: none;
         border-image: none;
     }
-
-    .lightdm.button:focused,
     .lightdm.entry:focused {
-        border-color: alpha (white, 0.9);
+        border-color: alpha($white, 0.6);
         border-width: 1px;
         border-style: solid;
-        color: white;
+        color: $white;
     }
-
     .lightdm.entry:selected {
-        background-color: alpha (white, 0.2);
+        background-color: alpha($white, 0.2);
     }
 
     @keyframes dashentry_spinner {
@@ -79,7 +96,7 @@
     }
 
     .lightdm.option-button {
-        padding: 2px;
+        padding: 5px;
         background: none;
         border: 0;
     }
@@ -88,9 +105,14 @@
         background: none;
         border-width: 0;
     }
-
+    .lightdm.toggle-button.selected:hover {
+        background-color: alpha($white, 0.3);
+        border-color: alpha($white, 0.3);
+        border-width: 1px;
+    }
     .lightdm.toggle-button.selected {
-        background-color: alpha (black, 0.3);
+        background-color: alpha($black, 0.3);
+        border-color: alpha($white, 0.3);
         border-width: 1px;
     }
 }

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -1,0 +1,96 @@
+/***********************
+ ! Unity Greeter *
+ ***********************/
+
+@include exports("unity-greeter") {
+    .lightdm.menu {
+        background-image: none;
+        background-color: #00ff00;
+        border-color: #00ff00;
+        border-radius: 4px;
+        padding: 1px;
+        color: #00ff00;
+    }
+
+    .lightdm-combo .menu {
+        background-color: #00ff00;
+        border-radius: 0px;
+        padding: 0px;
+        color: #00ff00;
+    }
+
+    .lightdm.menu .menuitem *,
+    .lightdm.menu .menuitem.check:active,
+    .lightdm.menu .menuitem.radio:active {
+        color: #00ff00;
+    }
+
+    .lightdm.menubar {
+        background-image: none;
+        background-color: #00ff00;
+    }
+
+    .lightdm-combo.combobox-entry .button,
+    .lightdm-combo .cell,
+    .lightdm-combo .button,
+    .lightdm-combo .entry,
+    .lightdm.button,
+    .lightdm.entry {
+        background-image: none;
+        background-color: alpha (black, 0.3);
+        border-color: alpha (white, 0.6);
+        border-radius: 5px;
+        padding: 7px;
+        color: white;
+        text-shadow: none;
+    }
+
+    .lightdm.button,
+    .lightdm.button:hover,
+    .lightdm.button:active,
+    .lightdm.button:active:focused,
+    .lightdm.entry,
+    .lightdm.entry:hover,
+    .lightdm.entry:active,
+    .lightdm.entry:active:focused {
+        background-image: none;
+        border-image: none;
+    }
+
+    .lightdm.button:focused,
+    .lightdm.entry:focused {
+        border-color: alpha (white, 0.9);
+        border-width: 1px;
+        border-style: solid;
+        color: white;
+    }
+
+    .lightdm.entry:selected {
+        background-color: alpha (white, 0.2);
+    }
+
+    @keyframes dashentry_spinner {
+        to { -gtk-icon-transform: rotate(1turn); }
+    }
+
+    .lightdm.entry:active {
+        -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+        animation: dashentry_spinner 1s infinite linear;
+    }
+
+    .lightdm.option-button {
+        padding: 2px;
+        background: none;
+        border: 0;
+    }
+
+    .lightdm.toggle-button {
+        background: none;
+        border-width: 0;
+    }
+
+    .lightdm.toggle-button.selected {
+        background-color: alpha (black, 0.3);
+        border-width: 1px;
+    }
+}


### PR DESCRIPTION
With a lot of reverse engineering I was able to implement support for the unity-greeter.
The DE selection / password dialog alrready looks great, the problem is the menubar. I am not able to modify it. It seems that it is overwritten by something else (I don't know by what...)
But as far as the most obvious inconsistencies are concerned this PR fixes them

![unbenannt](https://cloud.githubusercontent.com/assets/6475757/9178497/cceed812-3f97-11e5-9970-46609c5ace4b.png)
