### PR TITLE
Fixes wrong menubar color in gtk apps issue: #253

### DIFF
--- a/gtk-3.0/scss/_global.scss
+++ b/gtk-3.0/scss/_global.scss
@@ -47,8 +47,8 @@ $titlebar_fg_color: $dark_fg_color;
 $menu_bg_color: $dark_bg_color;
 $menu_fg_color: $dark_fg_color;
 
-$menubar_bg_color: $bg_color;
-$menubar_fg_color: $fg_color;
+$menubar_bg_color: $dark_bg_color;
+$menubar_fg_color: $dark_fg_color;
 
 $panel_bg_color: $dark_bg_color;
 $panel_fg_color: $dark_fg_color;


### PR DESCRIPTION
This fixes wrong menubar color for gtk (>=GTK-3.16) apps in master branch (Issue: #253 ). The regression appeared after master branch moved to Sass.
