### PR TITLE
Refinement for unity-greeter

### DIFF
--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -19,7 +19,6 @@
     background-color: shade($dark_bg_color, 1.08);
     border-radius: 0px;
     padding: 0px;
-
     color: $white;
 }
 
@@ -33,7 +32,10 @@
     background-image: none;
     background-color: fade-out(#00ff00, 0.5);
 }
-
+ .lightdm.menubar .menuitem {
+     color: $menubar_bg_color;
+     padding: 0px 5px 0px 5px;
+ }
 
     .lightdm-combo.combobox-entry .button,
     .lightdm-combo .cell,

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -7,8 +7,8 @@
 
     .lightdm.menu {
         background-image: none;
-        background-color: fade-out($black, 0.4);
-        border-color: fade-out($white, 0.8);
+        background-color: fade-out($black, .4);
+        border-color: fade-out($white, .8);
         border-radius: 4px;
         padding: 1px;
 
@@ -17,8 +17,8 @@
 
     .lightdm-combo .menu {
         background-color: shade($dark_bg_color, 1.08);
-        border-radius: 0px;
-        padding: 0px;
+        border-radius: 0;
+        padding: 0;
         color: $white;
     }
 
@@ -30,8 +30,9 @@
 
     .lightdm.menubar {
         background-image: none;
-        background-color: fade-out(#00ff00, 0.5);
+        background-color: fade-out(#0f0, .5);
     }
+    
     .lightdm.menubar .menuitem {
         color: $menubar_bg_color;
         padding: 0 5px;
@@ -44,16 +45,16 @@
     
     .lightdm.button{
         background-image: none;
-        background-color: fade-out($black, 0.7);
-        border-color: fade-out($white, 0.1);
+        background-color: fade-out($black, .7);
+        border-color: fade-out($white, .1);
         border-radius: 5px;
         padding: 5px;
         color: $white;
         }
     .lightdm.button:hover {
         background-image: none;
-        background-color: fade-out($white, 0.7);
-        border-color: fade-out($white, 0.4);
+        background-color: fade-out($white, .7);
+        border-color: fade-out($white, .4);
         border-radius: 5px;
         padding: 5px;
         color: $white;
@@ -65,8 +66,8 @@
 
     .lightdm.entry {
         background-image: none;
-        background-color: fade-out($black, 0.7);
-        border-color: fade-out($white, 0.4);
+        background-color: fade-out($black, .7);
+        border-color: fade-out($white, .4);
         border-radius: 5px;
         padding: 7px;
         color: $white;
@@ -79,13 +80,13 @@
         border-image: none;
     }
     .lightdm.entry:focused {
-        border-color: fade-out($white, 0.4);
+        border-color: fade-out($white, .4);
         border-width: 1px;
         border-style: solid;
         color: $white;
     }
     .lightdm.entry:selected {
-        background-color: fade-out($white, 0.8);
+        background-color: fade-out($white, .8);
     }
 
     @keyframes dashentry_spinner {
@@ -108,13 +109,13 @@
         border-width: 0;
     }
     .lightdm.toggle-button.selected:hover {
-        background-color: fade-out($white, 0.7);
-        border-color: fade-out($white, 0.7);
+        background-color: fade-out($white, .7);
+        border-color: fade-out($white, .7);
         border-width: 1px;
     }
     .lightdm.toggle-button.selected {
-        background-color: fade-out($black, 0.7);
-        border-color: fade-out($white, 0.7);
+        background-color: fade-out($black, .7);
+        border-color: fade-out($white, .7);
         border-width: 1px;
     }
 }

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -5,37 +5,37 @@
 @include exports("unity-greeter") {
 
 
-.lightdm.menu {
-    background-image: none;
-    background-color: fade-out($black, 0.4);
-    border-color: fade-out($white, 0.8);
-    border-radius: 4px;
-    padding: 1px;
+    .lightdm.menu {
+        background-image: none;
+        background-color: fade-out($black, 0.4);
+        border-color: fade-out($white, 0.8);
+        border-radius: 4px;
+        padding: 1px;
 
-    color: $white;
-}
+        color: $white;
+    }
 
-.lightdm-combo .menu {
-    background-color: shade($dark_bg_color, 1.08);
-    border-radius: 0px;
-    padding: 0px;
-    color: $white;
-}
+    .lightdm-combo .menu {
+        background-color: shade($dark_bg_color, 1.08);
+        border-radius: 0px;
+        padding: 0px;
+        color: $white;
+    }
 
-.lightdm.menu .menuitem *,
-.lightdm.menu .menuitem.check:active,
-.lightdm.menu .menuitem.radio:active {
-    color: $white;
-}
+    .lightdm.menu .menuitem *,
+    .lightdm.menu .menuitem.check:active,
+    .lightdm.menu .menuitem.radio:active {
+        color: $white;
+    }
 
-.lightdm.menubar {
-    background-image: none;
-    background-color: fade-out(#00ff00, 0.5);
-}
- .lightdm.menubar .menuitem {
-     color: $menubar_bg_color;
-     padding: 0px 5px 0px 5px;
- }
+    .lightdm.menubar {
+        background-image: none;
+        background-color: fade-out(#00ff00, 0.5);
+    }
+    .lightdm.menubar .menuitem {
+        color: $menubar_bg_color;
+        padding: 0 5px;
+    }
 
     .lightdm-combo.combobox-entry .button,
     .lightdm-combo .cell,


### PR DESCRIPTION
Changes unity greeter from this:
![bildschirmfoto vom 2015-10-31 08-08-50](https://cloud.githubusercontent.com/assets/6475757/10862673/76622002-7fb2-11e5-8ed5-6ed43538e912.png)

to this:
![bildschirmfoto vom 2015-10-31 08-09-36](https://cloud.githubusercontent.com/assets/6475757/10862674/7b2d151a-7fb2-11e5-8ded-f6f0679dc99e.png)

Btw: I wasn't able to fix the color of the text in the left corner, anyone any idea what I have to change to see an effect there? (It is obviously some kind of `menubar .menuitem:inactive`, but changing `color` doesn't help)
