### PR TITLE
Removes redundant entries for unity-greeter

### DIFF
--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -28,14 +28,9 @@
         color: $white;
     }
 
-    .lightdm.menubar {
-        background-image: none;
-        background-color: fade-out(#0f0, .5);
-    }
-    
+    .lightdm.menubar *,    
     .lightdm.menubar .menuitem {
-        color: $menubar_fg_color;
-        padding: 0 5px;
+        padding: 2px 2px;
     }
 
     .lightdm-combo.combobox-entry .button,

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -30,7 +30,7 @@
 
     .lightdm.menubar *,    
     .lightdm.menubar .menuitem {
-        padding: 2px 2px;
+        padding: 2px;
     }
 
     .lightdm-combo.combobox-entry .button,


### PR DESCRIPTION
Ok the last time I've refined the whole thing, by removing unncessary entries and adjusted padding according to global settings. Greeter now looks like it should.
![bildschirmfoto vom 2015-10-31 14-06-44](https://cloud.githubusercontent.com/assets/6475757/10863719/af397eae-7fd8-11e5-9c89-80e166f99ef8.png)
