### PR TITLE
gtk-3.0: Add support for undershoot and overshoot

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -1494,6 +1494,32 @@ GtkModelButton.button:selected {
     background-color: shade(@theme_base_color, 0.95);
 }
 
+/*************
+ * overshoot *
+ *************/
+.overshoot.top {
+    background: -gtk-gradient(radial, center top, 0, center top, 0.7, from(shade(@bg_color, 0.92)), to(alpha(@bg_color, 0.0)));
+}
+
+.overshoot.right {
+    background: -gtk-gradient(radial, right center, 0, right center, 0.7, from(shade(@bg_color, 0.92)), to(alpha(@bg_color, 0.0)));
+}
+
+.overshoot.bottom {
+    background: -gtk-gradient(radial, center bottom, 0, center bottom, 0.7, from(shade(@bg_color, 0.92)), to(alpha(@bg_color, 0.0)));
+}
+
+.overshoot.left {
+    background: -gtk-gradient(radial, left center, 0, left center, 0.7, from(shade(@bg_color, 0.92)), to(alpha(@bg_color, 0.0)));
+}
+
+/**************
+ * undershoot *
+ **************/
+.undershoot {
+    background: none;
+}
+
 /******************
  * pane separator *
  ******************/


### PR DESCRIPTION
This commit adds CSS rules to theme undershoot and overshoot. This is
what some applications use to indicate that there is more content below
and/or above the current content viewport.

This is notably used for Nautilus. Without those styles, those classes
are shown as an opaque gray area which looks bad and hides information.
