### PR TITLE
gtk-3.0: Fix Nautilus places sidebar

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3664,6 +3664,12 @@ GtkProgressBar.osd.progressbar {
     background-color: @osd_bg;
 }
 
+/* notably used in Nautilus */
+.sidebar GtkPlacesSidebar {
+    /* fixes opaque grey area for the overshoot and undershoot areas */
+    background: rgba(0, 0, 0, 0);
+}
+
 /******************************
  * destructive action buttons *
  ******************************/


### PR DESCRIPTION
This fixes Nautilus's places sidebar which had an opaque grey area
where the overshoot/undershoot transparent areas were meant to be.

Without the fix:
![without the added rule](https://cloud.githubusercontent.com/assets/4209061/11766962/e0aa4280-a19c-11e5-8b64-12de3af5b8a9.png)

With the added rule:
![with the rule](https://cloud.githubusercontent.com/assets/4209061/11767042/518287d0-a1a0-11e5-8c25-26715e84f7cc.png)
