### PR TITLE
Small fixes for gtkCalender and lightdm greeter

### DIFF
--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -64,7 +64,7 @@
         background-color: fade-out($black, .7);
         border-color: fade-out($white, .4);
         border-radius: 5px;
-        padding: 7px;
+        padding: 6px;
         color: $white;
         text-shadow: none;
     }
@@ -93,10 +93,10 @@
         animation: dashentry_spinner 1s infinite linear;
     }
 
+    
     .lightdm.option-button {
-        padding: 5px;
         background: none;
-        border: 0;
+        border-width: 0;
     }
 
     .lightdm.toggle-button {

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -93,7 +93,6 @@
         animation: dashentry_spinner 1s infinite linear;
     }
 
-    
     .lightdm.option-button {
         background: none;
         border-width: 0;

--- a/gtk-3.0/scss/apps/_unity-greeter.scss
+++ b/gtk-3.0/scss/apps/_unity-greeter.scss
@@ -98,6 +98,10 @@
         border-width: 0;
     }
 
+    .lightdm.option-button:insensitive:insensitive {
+        background: none;
+    }
+
     .lightdm.toggle-button {
         background: none;
         border-width: 0;

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -16,6 +16,7 @@
                 color: $selected_bg_color;
             }
         }
+
         &.view, &.highlight, &.header, &.button {
             &, &:focus, &:hover, &:insensitive {
                 background-color: transparent;
@@ -24,6 +25,7 @@
                 border-radius: 0;
             }
         }
+
         &.button {
             &, &:focus, &:hover, &:insensitive {
                 color: $white;
@@ -31,8 +33,10 @@
                 box-shadow: none;
             }
         }
+
         &.highlight { color: $selected_bg_color; }
     }
+
     /* gnome-calendar */
     .calendar-view {
         background-color: $base_color;

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -4,7 +4,6 @@
 
 @include exports("calendar") {
     GtkCalendar {
-        margin: 4px;
         padding: 1px 5px;
         outline-offset: -1px;
 

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -4,7 +4,7 @@
 
 @include exports("calendar") {
     GtkCalendar {
-        padding: 1px 5px;
+        padding: 1px 3px;
         outline-offset: -1px;
 
         &:inconsistent { color: mix($fg_color, $bg_color, .5); }

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -7,7 +7,7 @@
         margin: 4px;
         padding: $spacing;
         outline-offset: -1px;
-    
+
         &:inconsistent { color: mix($fg_color, $bg_color, .5); }
 
         &:selected {
@@ -16,7 +16,6 @@
                 color: $selected_bg_color;
             }
         }
-
         &.view, &.highlight, &.header, &.button {
             &, &:focus, &:hover, &:insensitive {
                 background-color: transparent;
@@ -25,7 +24,6 @@
                 border-radius: 0;
             }
         }
-        
         &.button {
             &, &:focus, &:hover, &:insensitive {
                 color: $white;
@@ -33,10 +31,8 @@
                 box-shadow: none;
             }
         }
-        
         &.highlight { color: $selected_bg_color; }
     }
-
     /* gnome-calendar */
     .calendar-view {
         background-color: $base_color;

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -35,6 +35,5 @@
         background-color: $base_color;
         color: $text_color;
     }
-    
 }
 

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -4,19 +4,36 @@
 
 @include exports("calendar") {
     GtkCalendar {
+        margin: 4px;
         padding: $spacing;
         outline-offset: -1px;
-
+    
         &:inconsistent { color: mix($fg_color, $bg_color, .5); }
 
-        &.view, &.highlight, &.header, &.button {
+        &:selected {
             &, &:focus, &:hover, &:insensitive {
-                border: 0;
                 background-color: transparent;
-                background-image: none;
+                color: $selected_bg_color;
             }
         }
 
+        &.view, &.highlight, &.header, &.button {
+            &, &:focus, &:hover, &:insensitive {
+                background-color: transparent;
+                background-image: none;
+                border-width: 0;
+                border-radius: 0;
+            }
+        }
+        
+        &.button {
+            &, &:focus, &:hover, &:insensitive {
+                color: $white;
+                border-width: 0;
+                box-shadow: none;
+            }
+        }
+        
         &.highlight { color: $selected_bg_color; }
     }
 

--- a/gtk-3.0/scss/widgets/_calendar.scss
+++ b/gtk-3.0/scss/widgets/_calendar.scss
@@ -5,17 +5,10 @@
 @include exports("calendar") {
     GtkCalendar {
         margin: 4px;
-        padding: $spacing;
+        padding: 1px 5px;
         outline-offset: -1px;
 
         &:inconsistent { color: mix($fg_color, $bg_color, .5); }
-
-        &:selected {
-            &, &:focus, &:hover, &:insensitive {
-                background-color: transparent;
-                color: $selected_bg_color;
-            }
-        }
 
         &.view, &.highlight, &.header, &.button {
             &, &:focus, &:hover, &:insensitive {
@@ -42,5 +35,6 @@
         background-color: $base_color;
         color: $text_color;
     }
+    
 }
 


### PR DESCRIPTION
The buttons from the GtkCalendar became almost invisible when hovering over them + the background of the selected day was completely misaligned, so I removed it and changed the font color of the selected day instead. 

Also a very small fix for the lightdm greeter where a to large padding caused the box to shift when entering a wrong password. So I reduced it by 1px

Before:
![bildschirmfoto 2015-12-28 14 06 44](https://cloud.githubusercontent.com/assets/6475757/12019377/ca0b4482-ad6f-11e5-92a2-031bad137c82.png)

After:

![bildschirmfoto 2015-12-28 14 08 25](https://cloud.githubusercontent.com/assets/6475757/12019384/d1a2aa1e-ad6f-11e5-880b-91ba2b778555.png)
