### PR TITLE
Progressbar style fix and update.

### DIFF
--- a/gtk-3.0/scss/widgets/_view.scss
+++ b/gtk-3.0/scss/widgets/_view.scss
@@ -127,29 +127,50 @@
             background-image: none;
         }
 
-        .progressbar,
-        .progressbar:selected,
-        .progressbar:selected:focus {
+        .progressbar {
             @include linear-gradient($selected_bg_color);
-            border: 1px solid mix($selected_bg_color, $selected_fg_color, .2);
+            border: 1px solid border_normal($selected_bg_color);
+
+            &:selected {
+                &:focus, & {
+                    @include linear-gradient($selected_bg_color);
+                    border: 1px solid border_focus($selected_bg_color);
+                    color: $selected_fg_color;
+                }
+
+                &:backdrop { }
+            }
+
+            &:insensitive {
+                &:insensitive {
+                    @include linear-gradient($bg_color);
+                    border-color: border_insensitive($bg_color);
+                }
+            }
+
+            &:backdrop {
+                @include linear-gradient($bg_color);
+                border-color: border_insensitive($bg_color);
+            }
         }
 
-        .trough,
-        .trough:selected,
-        .trough:selected:focus {
+        .trough {
             background-color: mix($bg_color, $base_color, .5);
-            border: 1px solid $bg_color;
-        }
+            border: 1px solid border_normal($base_color);
 
-        .progressbar:insensitive,
-        .progressbar:insensitive:insensitive {
-            @include linear-gradient($bg_color);
-            border-color: $bg_color;
-        }
+            &:selected {
+                &:focus, & {
+                    background-color: $base_color;
+                    border: 1px solid border_focus($bg_color);
+                    color: $text_color;
+                }
+            }
 
-        .trough:insensitive,
-        .trough:insensitive:insensitive {
-            background-color: $base_color;
+            &:insensitive {
+                &:insensitive {
+                    background-color: $base_color;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Sample:

gnome-system-manager: https://db.tt/26TAEu1n
transmission-gtk: insensitive: selected https://db.tt/eGeFUffa and not selected: https://db.tt/AwJyOUEn
transmission-gtk: normal: https://db.tt/2eYLBvDC
transmission-gtk and gnome-system-monitor: backdrop: https://db.tt/vDsGh6gF

Other: bug ? https://db.tt/d5DFO9PM (Mouse moved), https://db.tt/oo9LuK80 not updated backdrop style (transmission-gtk, Baobab not activated window). Adwaita theme not reproducted bug.
gnome-system-manager not reproducted bug.
