### PR TITLE
gtk3.20: [Nemo] Fixed backdrop->selected icon black bug.

### DIFF
--- a/gtk-3.20/scss/apps/_nemo.scss
+++ b/gtk-3.20/scss/apps/_nemo.scss
@@ -6,7 +6,6 @@
     .nemo-desktop, .nemo-desktop * {
         color: $white;
         text-shadow: 1px 1px $black;
-        background: transparent;
         border: none;
 
         &:active {


### PR DESCRIPTION
Fixed bug: 
![image](https://cloud.githubusercontent.com/assets/461493/14425922/4c80cb62-ffeb-11e5-8d9f-b9c9178d94e8.png)
