### PR TITLE
gtk3.20: Combobox pan-down icon fix.

### DIFF
--- a/gtk-3.20/scss/widgets/_button.scss
+++ b/gtk-3.20/scss/widgets/_button.scss
@@ -306,6 +306,12 @@
 
 @include exports("combobox") {
     combobox {
+        arrow {
+            -gtk-icon-source: -gtk-icontheme('pan-down-symbolic');
+            min-height: 16px;
+            min-width: 16px;
+        }
+
         box button, box entry {
             @extend %linked_button;
             padding: ($spacing - 2px) ($spacing + 1px);


### PR DESCRIPTION
Old:
![image](https://cloud.githubusercontent.com/assets/461493/14473251/6de75642-00f7-11e6-8842-8d8943d3dca5.png)

New:
![image](https://cloud.githubusercontent.com/assets/461493/14473256/719dc938-00f7-11e6-9ca8-bf656b4449f8.png)
