### PR TITLE
GTK 3.20: Fix selected text color for unfocused windows

### DIFF
--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -103,7 +103,7 @@ $backdrop_text_color: mix($backdrop_base_color, $text_color, .8);
 $backdrop_bg_color: $bg_color;
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, .5);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
-$backdrop_selected_fg_color: if($variant == 'light', $backdrop_text_color, $backdrop_base_color);
+$backdrop_selected_fg_color: mix($selected_bg_color, $selected_fg_color, .66);
 $backdrop_borders_color: mix($bg_color, $borders_color, .9);
 $backdrop_dark_fill: mix($backdrop_borders_color, $backdrop_bg_color, .35);
 $backdrop_sidebar_bg_color: mix($backdrop_bg_color, $backdrop_base_color, .5);


### PR DESCRIPTION
Before:
![screenshot from 2016-04-14 18-30-34](https://cloud.githubusercontent.com/assets/1887387/14536135/3c2618ac-0271-11e6-849f-71b72cf0f69b.png)

After:
![screenshot from 2016-04-14 18-31-26](https://cloud.githubusercontent.com/assets/1887387/14536167/5cc7623c-0271-11e6-8f80-580872fc27f0.png)
