### PR TITLE
Fix #350: Cursor almost invisible

### DIFF
--- a/gtk-3.20/scss/widgets/_entry.scss
+++ b/gtk-3.20/scss/widgets/_entry.scss
@@ -71,6 +71,7 @@
     @include border($bg);
 
     color: $fg;
+    caret-color: $fg;
 
     &:focus, &:active { border-color: border_focus($selected_borders_color); }
 


### PR DESCRIPTION
The caret color was never set in the theme and thus only the default was
used. This worked for the light version, but created an almost invisible
caret in the dark variant.

This should inject the caret-color property for all entry widgets, but
some locations might be missed nonetheless.

There is also a second property "-gtk-secondary-caret-color" which is
"used for the secondary caret in bidirectional text" according to the
documentation, but I do not know which this secondary caret is, so I did
not touch it.
