### PR TITLE
gtk3.20: Fixed nemo desktop 1px border bug.

### DIFF
--- a/gtk-3.20/scss/apps/_nemo.scss
+++ b/gtk-3.20/scss/apps/_nemo.scss
@@ -108,16 +108,6 @@
             border: 0;
         }
 
-        paned {
-            border-width: 0 1px 0 0;
-            border-style: solid;
-
-            &, &:hover {
-                border-color: shade($bg_color, ($contrast + .1));
-                background-color: $bg_color;
-            }
-        }
-
         notebook {
             border-width: 0;
 


### PR DESCRIPTION
Desktop bug: 
![image](https://cloud.githubusercontent.com/assets/461493/14532125/3fcc83ee-0260-11e6-9970-cfd64425338d.png)
(Right monitor)
magnified:
![image](https://cloud.githubusercontent.com/assets/461493/14532277/d01decf8-0260-11e6-9556-67c0cfafc79e.png)
1 px size white border.

Code bug: https://github.com/shimmerproject/Numix/blob/master/gtk-3.20/scss/apps/_nemo.scss#L112
