### PR TITLE
[gtk3.20] Redesign windows csd decoration

### DIFF
--- a/gtk-3.0/scss/widgets/_window.scss
+++ b/gtk-3.0/scss/widgets/_window.scss
@@ -52,7 +52,8 @@
 
         &.ssd {
             // Fixed gtk-3.18 Unity bug (https://github.com/numixproject/numix-gtk-theme/issues/270)
-            box-shadow: 0 0 0 1px transparent;
+            box-shadow: 0 0 0 1px $wm_border_focused;
+
             &.maximized { border-radius: 0; }
         }
     }

--- a/gtk-3.0/scss/widgets/_window.scss
+++ b/gtk-3.0/scss/widgets/_window.scss
@@ -51,6 +51,8 @@
         }
 
         &.ssd {
+            // Fixed gtk-3.18 Unity bug (https://github.com/numixproject/numix-gtk-theme/issues/270)
+            box-shadow: 0 0 0 1px transparent;
             &.maximized { border-radius: 0; }
         }
     }

--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -31,9 +31,6 @@ $white: #fff;
 $button_border: shade($base_color, .9);
 $entry_border: alpha($dark_shadow, .06);
 
-$top_hilight: $borders_edge;
-$headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-
 $scrollbar_bg_color: if($variant == 'light', darken($bg_color, 5%), mix($base_color, $bg_color, .4));
 $scrollbar_slider_color: shade($bg_color, .5);
 $scrollbar_slider_hover_color: shade($bg_color, .3);
@@ -84,8 +81,8 @@ $lightdm_bg_color: $dark_bg_color;
 $lightdm_fg_color: $dark_fg_color;
 
 $wm_bg: $titlebar_bg_color;
-$wm_border_focused: if($variant == 'light', transparentize($black, .5), transparentize($borders_color, .1));
-$wm_border_unfocused: if($variant == 'light', transparentize($black, .55), transparentize($borders_color, .1));
+$wm_border_focused: transparent;
+$wm_border_unfocused: transparent;
 $wm_title_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);
 $wm_title_unfocused: mix($titlebar_fg_color, $titlebar_bg_color, .4);
 $wm_icons_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);

--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -84,8 +84,8 @@ $lightdm_bg_color: $dark_bg_color;
 $lightdm_fg_color: $dark_fg_color;
 
 $wm_bg: $titlebar_bg_color;
-$wm_border_focused: if($variant=='light', transparentize($black, .5), transparentize($borders_color, .1));
-$wm_border_unfocused: if($variant=='light', transparentize($black, .55), transparentize($borders_color, .1));
+$wm_border_focused: if($variant == 'light', transparentize($black, .5), transparentize($borders_color, .1));
+$wm_border_unfocused: if($variant == 'light', transparentize($black, .55), transparentize($borders_color, .1));
 $wm_title_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);
 $wm_title_unfocused: mix($titlebar_fg_color, $titlebar_bg_color, .4);
 $wm_icons_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);

--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -31,6 +31,9 @@ $white: #fff;
 $button_border: shade($base_color, .9);
 $entry_border: alpha($dark_shadow, .06);
 
+$top_hilight: $borders_edge;
+$headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
+
 $scrollbar_bg_color: if($variant == 'light', darken($bg_color, 5%), mix($base_color, $bg_color, .4));
 $scrollbar_slider_color: shade($bg_color, .5);
 $scrollbar_slider_hover_color: shade($bg_color, .3);
@@ -81,8 +84,8 @@ $lightdm_bg_color: $dark_bg_color;
 $lightdm_fg_color: $dark_fg_color;
 
 $wm_bg: $titlebar_bg_color;
-$wm_border_focused: transparent;
-$wm_border_unfocused: transparent;
+$wm_border_focused: if($variant=='light', transparentize($black, .5), transparentize($borders_color, .1));
+$wm_border_unfocused: if($variant=='light', transparentize($black, .55), transparentize($borders_color, .1));
 $wm_title_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);
 $wm_title_unfocused: mix($titlebar_fg_color, $titlebar_bg_color, .4);
 $wm_icons_focused: mix($titlebar_fg_color, $titlebar_bg_color, .1);

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -31,9 +31,11 @@
             border-radius: 0;
             margin: 1px;
             background-color: $bg_color;
-            box-shadow: inset 0 0 0 3px $headerbar_color, inset 0 1px $top_hilight;
+            // Unity/compiz regression: Issue: https://github.com/numixproject/numix-gtk-theme/issues/206
+            box-shadow: none;
+            //box-shadow: inset 0 0 0 3px $headerbar_color, inset 0 1px $top_hilight;
 
-            &:backdrop { box-shadow: inset 0 0 0 3px $backdrop_bg_color, inset 0 1px $top_hilight; }
+            //&:backdrop { box-shadow: inset 0 0 0 3px $backdrop_bg_color, inset 0 1px $top_hilight; }
         }
 
         .csd.popup & {

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -4,6 +4,8 @@
 
 @include exports("window") {
     decoration {
+        $_wm_border: if($variant == 'light', transparentize($black, .77), transparentize($borders_color, .1));
+
         border-radius: $roundness $roundness 0 0;
         // lamefun trick to get rounded borders regardless of CSD use
         border-width: 0;
@@ -38,7 +40,7 @@
 
         .csd.popup & {
             border-radius: 0;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
         }
 
         tooltip.csd & {
@@ -48,7 +50,7 @@
 
         messagedialog.csd & {
             border-radius: $roundness;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
         }
     }
 }

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -1,9 +1,7 @@
-/**************
- ! Window frame
-***************/
-
 @include exports("window") {
     decoration {
+        $_wm_border: if($variant == 'light', transparentize($black, .77), transparentize($borders_color, .1));
+
         border-radius: $roundness $roundness 0 0;
         // lamefun trick to get rounded borders regardless of CSD use
         border-width: 0;
@@ -40,7 +38,7 @@
 
         .csd.popup & {
             border-radius: 0;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
         }
 
         tooltip.csd & {
@@ -50,7 +48,7 @@
 
         messagedialog.csd & {
             border-radius: $roundness;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
         }
     }
 }

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -23,8 +23,8 @@
         // this needs to be transparent
         // see bug #722563
         // server-side decorations as used by mutter
-        //.ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
-        .ssd & { box-shadow: 0 0 0 1px transparent; } //just doing borders, wm draws actual shadows
+        // Fixed gtk-3.18 Unity bug (https://github.com/numixproject/numix-gtk-theme/issues/270)
+        .ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
 
         .solid-csd & {
             border-radius: 0;

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -1,7 +1,9 @@
+/**************
+ ! Window frame
+***************/
+
 @include exports("window") {
     decoration {
-        $_wm_border: if($variant == 'light', transparentize($black, .77), transparentize($borders_color, .1));
-
         border-radius: $roundness $roundness 0 0;
         // lamefun trick to get rounded borders regardless of CSD use
         border-width: 0;
@@ -32,14 +34,11 @@
             background-color: $bg_color;
             // Unity/compiz regression: Issue: https://github.com/numixproject/numix-gtk-theme/issues/206
             box-shadow: none;
-            //box-shadow: inset 0 0 0 3px $headerbar_color, inset 0 1px $top_hilight;
-
-            //&:backdrop { box-shadow: inset 0 0 0 3px $backdrop_bg_color, inset 0 1px $top_hilight; }
         }
 
         .csd.popup & {
             border-radius: 0;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
         }
 
         tooltip.csd & {
@@ -49,7 +48,7 @@
 
         messagedialog.csd & {
             border-radius: $roundness;
-            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($_wm_border, .1);
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
         }
     }
 }

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -8,13 +8,13 @@
         // lamefun trick to get rounded borders regardless of CSD use
         border-width: 0;
 
-        box-shadow: 0 3px 9px 1px transparentize($black, .5), 0 0 0 1px $wm_border_focused; //doing borders with box-shadow
+        box-shadow: 0 3px 9px 1px transparentize($black, .3), 0 0 0 1px $wm_border_focused; //doing borders with box-shadow
 
         /* this is used for the resize cursor area */
         margin: $spacing * 3;
 
         &:backdrop {
-            box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px transparentize($black, .8), 0 0 0 1px $wm_border_unfocused;
+            box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px transparentize($black, .6), 0 0 0 1px $wm_border_unfocused;
             transition: 200ms ease-out;
         }
 
@@ -30,9 +30,7 @@
         .solid-csd & {
             border-radius: 0;
             margin: 1px;
-            box-shadow: none;
             background-color: $bg_color;
-            //border: solid 1px $dark_bg_color;
             box-shadow: inset 0 0 0 3px $headerbar_color, inset 0 1px $top_hilight;
 
             &:backdrop { box-shadow: inset 0 0 0 3px $backdrop_bg_color, inset 0 1px $top_hilight; }

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -3,44 +3,44 @@
 ***************/
 
 @include exports("window") {
-    %window {
-        box-shadow: 0 19px 38px rgba(0, 0, 0, .2), 0 15px 12px rgba(0, 0, 0, .1), 0 0 0 1px $wm_border_focused;
-
-        &:backdrop {
-            box-shadow: 0 10px 20px rgba(0, 0, 0, .19), 0 6px 6px rgba(0, 0, 0, .23), 0 0 0 1px $wm_border_unfocused;
-        }
-    }
-
     decoration {
-        @extend %window;
-
         border-radius: $roundness $roundness 0 0;
         // lamefun trick to get rounded borders regardless of CSD use
-        border-width: 0px;
+        border-width: 0;
+
+        box-shadow: 0 3px 9px 1px transparentize($black, .5), 0 0 0 1px $wm_border_focused; //doing borders with box-shadow
 
         /* this is used for the resize cursor area */
         margin: $spacing * 3;
 
-        .fullscreen &, .tiled & { border-radius: 0; }
+        &:backdrop {
+            box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px transparentize($black, .8), 0 0 0 1px $wm_border_unfocused;
+            transition: 200ms ease-out;
+        }
+
+        .maximized &, .fullscreen &, .tiled & { border-radius: 0; }
 
         .popup & { box-shadow: none; }
 
         // this needs to be transparent
         // see bug #722563
         // server-side decorations as used by mutter
-        .ssd & { box-shadow: 0 0 0 1px if($variant=='light', transparentize(black, .77), transparentize($borders_color, .1)); } //just doing borders, wm draws actual shadows
+        .ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
 
         .solid-csd & {
             border-radius: 0;
             margin: 1px;
-            background-color: $bg_color;
             box-shadow: none;
+            background-color: $bg_color;
+            //border: solid 1px $dark_bg_color;
+            box-shadow: inset 0 0 0 3px $headerbar_color, inset 0 1px $top_hilight;
+
+            &:backdrop { box-shadow: inset 0 0 0 3px $backdrop_bg_color, inset 0 1px $top_hilight; }
         }
 
         .csd.popup & {
-            @extend %window;
-
             border-radius: 0;
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
         }
 
         tooltip.csd & {
@@ -49,9 +49,8 @@
         }
 
         messagedialog.csd & {
-            @extend %window;
-
             border-radius: $roundness;
+            box-shadow: 0 1px 2px transparentize($black, .8), 0 0 0 1px transparentize($wm_border_focused, .1);
         }
     }
 }

--- a/gtk-3.20/scss/widgets/_window.scss
+++ b/gtk-3.20/scss/widgets/_window.scss
@@ -23,7 +23,8 @@
         // this needs to be transparent
         // see bug #722563
         // server-side decorations as used by mutter
-        .ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
+        //.ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
+        .ssd & { box-shadow: 0 0 0 1px transparent; } //just doing borders, wm draws actual shadows
 
         .solid-csd & {
             border-radius: 0;


### PR DESCRIPTION
Fixed and redesign:
- Window shadow bug fix (https://github.com/numixproject/numix-gtk-theme/commit/3cc526c0d6b1a59049b3d91ba490fb66b5281f1c)
- Added csd window border.

Old:
![image](https://cloud.githubusercontent.com/assets/461493/14755212/fbc9c77e-08e0-11e6-8a9a-8d8cb5d35702.png)

New:
![image](https://cloud.githubusercontent.com/assets/461493/14755219/068d160c-08e1-11e6-978a-1858f1f1719a.png)

Fix https://github.com/numixproject/numix-gtk-theme/issues/333
