### PR TITLE
Fix #387: app notification border and button style

### DIFF
--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -69,18 +69,22 @@
 **********************/
 
 @include exports("notifications") {
-    .app-notification {
-        &, &.frame {
-            border-style: solid;
-            border-color: border_normal($osd_bg);
-            border-width: 0 1px 1px;
-            border-radius: 0 0 $roundness $roundness;
-            padding: $spacing * 2;
-            background-color: $osd_bg;
-            background-image: none;
-            color: $osd_fg;
+    frame.app-notification {
+        border-style: solid;
+        border-color: border_normal($osd_bg);
+        border-width: 0 1px 1px;
+        border-radius: 0 0 $roundness $roundness;
+        padding: $spacing * 2;
+        background-color: $osd_bg;
+        background-image: none;
+        color: $osd_fg;
 
-            .button { @include button($osd_bg, $osd_fg); }
+        button {
+            @include button($osd_bg, $osd_fg);
+        }
+
+        border {
+            border: 0;
         }
     }
 }


### PR DESCRIPTION
**Before:**

![20160423_194749](https://cloud.githubusercontent.com/assets/922874/14763201/d8a110dc-098e-11e6-8aef-897b4a2ab400.png)

**After:**

![20160423_200223](https://cloud.githubusercontent.com/assets/922874/14763204/dd758e76-098e-11e6-9086-82a576d910e6.png)
