### PR TITLE
GTK 3.20 :: Popover frame fix

### DIFF
--- a/gtk-3.20/scss/widgets/_menu.scss
+++ b/gtk-3.20/scss/widgets/_menu.scss
@@ -255,7 +255,7 @@
             }
         }
 
-        frame {
+        .frame {
             border-color: border_normal($menu_bg_color);
             border-radius: $roundness;
         }


### PR DESCRIPTION
**Before:**
![image](https://cloud.githubusercontent.com/assets/461493/15137580/10fddede-168b-11e6-97a3-d75a1b7918d2.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/461493/15137590/16af844a-168b-11e6-9bb6-acfbe4b87297.png)
