### PR TITLE
GTK 3.20 :: Firefox tooltip fix

### DIFF
--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -15,6 +15,7 @@
 ************/
 
 @include exports("tooltip") {
+    .tooltip, // Firefox fix
     tooltip {
         &.background {
             &, &.csd {
@@ -22,10 +23,9 @@
                 background-clip: padding-box;
                 border: 1px solid border_normal($tooltip_bg_color);
                 border-radius: $roundness;
+                color: $tooltip_fg_color;
             }
         }
-
-        label { color: $tooltip_fg_color; }
 
         * {
             background-color: transparent;


### PR DESCRIPTION
Fixed bug: https://github.com/numixproject/numix-gtk-theme/pull/413#issuecomment-218294518
