### PR TITLE
GTK 3.20 :: Icon selected background color fix

### DIFF
--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -103,7 +103,7 @@ $backdrop_text_color: mix($backdrop_base_color, $text_color, .8);
 $backdrop_bg_color: $bg_color;
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, .5);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
-$backdrop_selected_fg_color: mix($selected_bg_color, $selected_fg_color, .66);
+$backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($bg_color, $borders_color, .9);
 $backdrop_dark_fill: mix($backdrop_bg_color, $backdrop_borders_color, .35);
 $backdrop_sidebar_bg_color: mix($backdrop_bg_color, $backdrop_base_color, .5);

--- a/gtk-3.20/scss/_widgets.scss
+++ b/gtk-3.20/scss/_widgets.scss
@@ -35,3 +35,6 @@
 @import "apps/xfce";
 @import "apps/unity";
 @import "apps/lightdm";
+
+// Fixed bug: https://github.com/numixproject/numix-gtk-theme/issues/430
+@import "widgets/extend";

--- a/gtk-3.20/scss/widgets/_extend.scss
+++ b/gtk-3.20/scss/widgets/_extend.scss
@@ -1,0 +1,23 @@
+/*******************
+ ! Selected Items  *
+********************/
+
+@include exports("selected_items") {
+    %selected_items {
+        background-color: $selected_bg_color;
+
+        @at-root %nobg_selected_items, & {
+            color: $selected_fg_color;
+
+            @if $variant == 'light' { outline-color: transparentize($selected_fg_color, .7); }
+
+            &:disabled { color: mix($selected_fg_color, $selected_bg_color, .5); }
+
+            &:backdrop {
+                color: $backdrop_selected_fg_color;
+
+                &:disabled { color: mix($backdrop_selected_fg_color, $selected_bg_color, .3); }
+            }
+        }
+    }
+}

--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -1,6 +1,6 @@
-/***************
-! Dimmed label *
-****************/
+/****************
+ ! Dimmed label *
+*****************/
 
 @include exports("dimlabel") {
     .dim-label {
@@ -278,29 +278,4 @@
 
 @include exports("stackswitcher") {
     stackswitcher button.text-button { min-width: 90px; } // FIXME aggregate with buttons
-}
-
-
-/*******************
- ! Selected Items  *
-********************/
-
-@include exports("selected_items") {
-    %selected_items {
-        background-color: $selected_bg_color;
-
-        @at-root %nobg_selected_items, & {
-            color: $selected_fg_color;
-
-            @if $variant == 'light' { outline-color: transparentize($selected_fg_color, .7); }
-
-            &:disabled { color: mix($selected_fg_color, $selected_bg_color, .5); }
-
-            &:backdrop {
-                color: $backdrop_selected_fg_color;
-
-                &:disabled { color: mix($backdrop_selected_fg_color, $selected_bg_color, .3); }
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fix: https://github.com/numixproject/numix-gtk-theme/issues/430

Sample:
![anim](https://cloud.githubusercontent.com/assets/461493/15267308/6c480f36-19be-11e6-88dd-653935a1a1ef.gif)
