### PR TITLE
GTK 3.20 :: Optimized headerbar padding size

### DIFF
--- a/gtk-3.20/scss/widgets/_toolbar.scss
+++ b/gtk-3.20/scss/widgets/_toolbar.scss
@@ -9,7 +9,7 @@
     @include linear-gradient($bg);
     @include border($bg);
 
-    padding: $spacing * 2;
+    padding: $spacing;
     color: $fg;
 
     &:disabled {


### PR DESCRIPTION
**Before:**
![image](https://cloud.githubusercontent.com/assets/461493/15276215/ff4c2c3a-1ae1-11e6-84b9-c7f272d61651.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/461493/15276219/115ac314-1ae2-11e6-8c2d-7aa914574f16.png)

Optimized notebook and other small display.
