### PR TITLE
GTK 3.20 :: Implement inline-toolbar background color and border

### DIFF
--- a/gtk-3.20/scss/_global.scss
+++ b/gtk-3.20/scss/_global.scss
@@ -105,7 +105,7 @@ $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, .5);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: mix($selected_bg_color, $selected_fg_color, .66);
 $backdrop_borders_color: mix($bg_color, $borders_color, .9);
-$backdrop_dark_fill: mix($backdrop_borders_color, $backdrop_bg_color, .35);
+$backdrop_dark_fill: mix($backdrop_bg_color, $backdrop_borders_color, .35);
 $backdrop_sidebar_bg_color: mix($backdrop_bg_color, $backdrop_base_color, .5);
 
 $backdrop_osd_base: $osd_base;

--- a/gtk-3.20/scss/widgets/_toolbar.scss
+++ b/gtk-3.20/scss/widgets/_toolbar.scss
@@ -63,11 +63,29 @@
 
         &.inline-toolbar {
             background-image: none;
-            background-color: transparent;
+            border-width: 0 1px 1px;
+            border-style: solid;
+            border-color: $borders_color;
+            background-color: mix($borders_color, $bg_color, .7);
+
+            &:backdrop {
+                border-color: $backdrop_borders_color;
+                background-color: $backdrop_dark_fill;
+                transition: 200ms ease-out;
+            }
 
             button { @include button($toolbar_bg_color, $toolbar_fg_color); }
 
-            .linked > button { @include linked_button($toolbar_bg_color); }
+            toolbutton,
+            toolbutton:backdrop {
+                > button.flat { @extend %linked_middle; }
+
+                &:first-child > button.flat { @extend %linked_button:first-child; }
+
+                &:last-child > button.flat { @extend %linked_button:last-child; }
+
+                &:only-child > button.flat { @extend %linked_button:only-child; }
+            }
         }
     }
 


### PR DESCRIPTION
**Before:**
![image](https://cloud.githubusercontent.com/assets/461493/15627024/b9257b68-24d6-11e6-8f46-becfde4a9302.png)
![image](https://cloud.githubusercontent.com/assets/461493/15627022/a67a614a-24d6-11e6-93c9-2980edc1c619.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/461493/15627012/6943179a-24d6-11e6-95de-318907bf21e6.png)
![image](https://cloud.githubusercontent.com/assets/461493/15627017/8f5aff10-24d6-11e6-8684-33ec46b90fd0.png)
