### PR TITLE
Set Numix as default icon theme for MATE's theme picker (#488)

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -6,5 +6,6 @@ Encoding=UTF-8
 
 [X-GNOME-Metatheme]
 GtkTheme=Numix
+IconTheme=Numix
 MetacityTheme=Numix
 ButtonLayout=:minimize,maximize,close


### PR DESCRIPTION
Choosing a default icon theme is required for Numix to show up in
MATE's theme picker (mate-appearance-properties)

Please install numix-icon-theme!
