### PR TITLE
Restore and fix Xfce desktop icon shadows. Fix #492

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -528,7 +528,7 @@ style "xfdesktop-icon-view" {
 	fg[ACTIVE] = @selected_fg_color
 
 	engine "murrine" {
-		textstyle = 0
+		textstyle = 5
 		text_shade = 0.05
 	}
 }

--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -517,20 +517,20 @@ style "xfdesktop-windowlist" {
 style "xfdesktop-icon-view" {
 	XfdesktopIconView::label-alpha = 0
 	XfdesktopIconView::selected-label-alpha = 60
-	XfdesktopIconVIew::ellipsize-icon-labels = 1
-
-	base[NORMAL] = @selected_bg_color
-	base[SELECTED] = @selected_bg_color
-	base[ACTIVE] = @selected_bg_color
+	XfdesktopIconView::shadow-x-offset = 0
+	XfdesktopIconView::shadow-y-offset = 1
+	XfdesktopIconView::selected-shadow-x-offset = 0
+	XfdesktopIconView::selected-shadow-y-offset = 1
+	XfdesktopIconView::shadow-color = "#000000"
+	XfdesktopIconView::selected-shadow-color = "#000000"
+	XfdesktopIconView::shadow-blur-radius = 2
+	XfdesktopIconView::cell-spacing = 2
+	XfdesktopIconView::cell-padding = 6
+	XfdesktopIconView::cell-text-width-proportion = 1.9
 
 	fg[NORMAL] = @selected_fg_color
-	fg[SELECTED] = @selected_fg_color
 	fg[ACTIVE] = @selected_fg_color
 
-	engine "murrine" {
-		textstyle = 5
-		text_shade = 0.05
-	}
 }
 
 style "xfwm-tabwin" {


### PR DESCRIPTION
Improved fix inspired by [arc-theme.](https://github.com/horst3180/arc-theme/commit/ee44856) and Greybird.
