### PR TITLE
Implement basic Gtk3 support for xfce4-notifyd. (#511)

### DIFF
--- a/xfce-notify-4.0/gtk.css
+++ b/xfce-notify-4.0/gtk.css
@@ -1,0 +1,34 @@
+#XfceNotifyWindow {
+	background-color: #111111;
+	border-color: #444444;
+	border-radius: 2px;
+	border-width: 1px;
+}
+
+#XfceNotifyWindow:hover {
+	border-color: #333333;
+}
+
+#XfceNotifyWindow label {
+	color: #f9f9f9;
+	-GtkWidget-link-color: #f0544c;
+}
+
+#XfceNotifyWindow label#summary {
+	font-weight: bold;
+}
+
+#XfceNotifyWindow button {
+	background-color: #444444;
+	color: #eeeeee;
+}
+
+#XfceNotifyWindow button:hover {
+	background-color: #555555;
+}
+
+#XfceNotifyWindow button:active {
+	background-color: #444444;
+}
+
+/* TODO: Implement progressbar style */


### PR DESCRIPTION
Pretty much just ported the old style from `gtkrc`. http://docs.xfce.org/apps/notifyd/theming instructs to use `#XfceNotifyWindow .osd` instead of just `#XfceNotifyWindow` if Gtk-3.20 is used. This doesn't work for me and if you take a look at the themes [here](https://git.xfce.org/apps/xfce4-notifyd/tree/themes/gtk-3.20), they also do not use it.

I don't know how to deal with the progressbar. It looks pretty good if the Numix Gtk theme is used.

I can only test this with Gtk-3.20 right now. It should work fine with Gtk-3.18 as well.

![image](https://cloud.githubusercontent.com/assets/703905/17681038/94b5c796-6343-11e6-96c3-88538e252a0e.png)

Fixes #511
