### PR TITLE
GTK 3.20 :: Fixed Circular button radius bug

### DIFF
--- a/gtk-3.20/scss/widgets/_button.scss
+++ b/gtk-3.20/scss/widgets/_button.scss
@@ -382,8 +382,8 @@
         .linked.vertical > & { @include linked_vertical_button(shade($bg_color, 1.2)); }
 
         &.circular { // FIXME: aggregate to buttons
-            border-radius: 20px;
-            -gtk-outline-radius: 20px;
+            border-radius: 9999px; // Fixed: https://github.com/GNOME/gtk/commit/a6409458f0d50d673a4dc370b9251993b7835b6b
+            -gtk-outline-radius: 9999px;
 
             label { padding: 0; }
         }

--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -280,7 +280,11 @@
     stackswitcher button {
         &.text-button { min-width: 90px; } // FIXME aggregate with buttons
 
-        &.circular { min-width: 0; } // FIXME aggregate with buttons
+        &.circular {  // FIXME aggregate with buttons
+            min-width: 32px;
+            min-height: 32px;
+            padding: 0;
+        }
     }
 }
 


### PR DESCRIPTION
Reference: https://github.com/GNOME/gtk/commit/a6409458f0d50d673a4dc370b9251993b7835b6b
