### PR TITLE
GTK 3.20 :: Fixed #447 and implement public colors code

### DIFF
--- a/gtk-3.20/scss/_colors.scss
+++ b/gtk-3.20/scss/_colors.scss
@@ -59,6 +59,27 @@
 @define-color lightdm_bg_color #{"" + $lightdm_bg_color};
 @define-color lightdm_fg_color #{"" + $lightdm_fg_color};
 
+/* widget text/foreground color on backdrop windows */
+@define-color theme_unfocused_fg_color #{"" + $backdrop_fg_color};
+
+/* text color for entries, views and content in general on backdrop windows */
+@define-color theme_unfocused_text_color #{"" + $text_color};
+
+/* widget base background color on backdrop windows */
+@define-color theme_unfocused_bg_color #{"" + $backdrop_bg_color};
+
+/* text widgets and the like base background color on backdrop windows */
+@define-color theme_unfocused_base_color #{"" + $backdrop_base_color};
+
+/* base background color of selections on backdrop windows */
+@define-color theme_unfocused_selected_bg_color #{"" + $selected_bg_color};
+
+/* text/foreground color of selections on backdrop windows */
+@define-color theme_unfocused_selected_fg_color #{"" + $selected_fg_color};
+
+/* insensitive color on backdrop windows*/
+@define-color unfocused_insensitive_color #{"" + $backdrop_insensitive_color};
+
 /* window manager colors */
 @define-color wm_bg #{"" + $wm_bg};
 @define-color wm_border_focused #{"" + $wm_border_focused};


### PR DESCRIPTION
Error cause: Not implement code (https://github.com/GNOME/baobab/blob/master/src/baobab.css#L33)

Sample: 
![image](https://cloud.githubusercontent.com/assets/461493/18034283/59cff728-6d39-11e6-839e-2ceef294b79d.png)
