### PR TITLE
GTK 3.20 :: Paned separator in the headerbar fixes #551 

### DIFF
--- a/gtk-3.20/scss/widgets/_sidebar.scss
+++ b/gtk-3.20/scss/widgets/_sidebar.scss
@@ -210,5 +210,9 @@
                 background-position: bottom, top;
             }
         }
+
+        &.titlebar > separator {
+            background-image: image(shade($titlebar_bg_color, ($contrast + .1)));
+        }
     }
 }


### PR DESCRIPTION
The problem is that the separator in the headerbar has the same style applied as the paned separator in the actual window.

Originally I fixed the problem in apps/_gedit.scss, but then I found out that the style is applied in widgets/_sidebar.scss, so I moved the fix there.

This has been bugging me for a while, at least since 3.18, I only applied the fix only for 3.20 because I couldn't test it on older versions

Result:
![geditok](https://cloud.githubusercontent.com/assets/1887387/18183289/f25bfbd8-7093-11e6-83cc-d6d33b5e89db.png)
