### PR TITLE
GTK 3.20 :: Default osd button color fix

### DIFF
--- a/gtk-3.20/scss/widgets/_osd.scss
+++ b/gtk-3.20/scss/widgets/_osd.scss
@@ -51,6 +51,8 @@
             background-origin: border-box;
         }
 
+        button { @include button($osd_bg, $osd_fg); }
+
         entry { @include entry($osd_base, $osd_text_color, $osd_borders_color); }
 
         /* used by gnome-settings-daemon's media-keys OSD */


### PR DESCRIPTION
**Before:**
![image](https://cloud.githubusercontent.com/assets/461493/18247941/e3636a46-7375-11e6-8bf7-60afec736d52.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/461493/18247948/ecf0d83c-7375-11e6-8558-c0deac0b9799.png)

Minimal correction... https://github.com/numixproject/numix-gtk-theme/commit/ff98d448fc01c637ddff3203c02095ceaca013f7
