### PR TITLE
GTK 3.20 :: Fixed infobar structure and  adding entry error and warning code.

### DIFF
--- a/src/gtk-3.20/scss/widgets/_entry.scss
+++ b/src/gtk-3.20/scss/widgets/_entry.scss
@@ -96,9 +96,11 @@
 
     &:focus, &:hover, &:active { transition: none; }
 
-    &:selected, &:selected:focus {
-        background-color: $selected_bg_color;
-        color: $selected_fg_color;
+    &:selected {
+        &, &:selected:focus {
+            background-color: $selected_bg_color;
+            color: $selected_fg_color;
+        }
     }
 
     &:disabled { box-shadow: none; }
@@ -115,7 +117,33 @@
 
     image.right { padding-left: $spacing; }
 
-    selection { &:focus, & { @extend %selected_items; } }
+    selection { @extend %selected_items; }
+
+    // entry error and warning style
+    @each $e_type, $e_color, $e_fg_color in (warning, $warning_bg_color, $warning_fg_color),
+                                            (error, $error_bg_color, $error_fg_color),
+                                            // entry.search-missing for Gnome-Builder
+                                            (search-missing, $error_bg_color, $error_fg_color) {
+        &.#{$e_type} {
+            color: $e_fg_color;
+            border-color: border_normal($e_color);
+            background-color: mix($base_color, $e_color, .6);
+
+            image { color: $e_fg_color; }
+
+            &:focus {
+                color: $e_fg_color;
+                border-color: border_focus($e_color);
+                background-color: $e_color;
+                box-shadow: none;
+            }
+
+            selection {
+                background-color: $e_fg_color;
+                color: $e_color;
+            }
+        }
+    }
 }
 
 @mixin entry($bg, $fg, $border: $borders_color) {

--- a/src/gtk-3.20/scss/widgets/_infobar.scss
+++ b/src/gtk-3.20/scss/widgets/_infobar.scss
@@ -8,30 +8,33 @@
 @include exports("infobar") {
     infobar {
         border: 0;
-    }
 
-    $types: (
-        info: ($info_fg_color, $info_bg_color),
-        warning: ($warning_fg_color, $warning_bg_color),
-        question: ($question_fg_color, $question_bg_color),
-        error: ($error_fg_color, $error_bg_color),
-    );
+        $types: (
+            info: ($info_fg_color, $info_bg_color),
+            warning: ($warning_fg_color, $warning_bg_color),
+            question: ($question_fg_color, $question_bg_color),
+            error: ($error_fg_color, $error_bg_color),
+        );
 
+        @each $type, $colors in $types {
+            $fg_color: nth($colors, 1);
+            $bg_color: nth($colors, 2);
 
-    @each $type, $colors in $types {
-        $fg_color: nth($colors, 1);
-        $bg_color: nth($colors, 2);
+            &.#{$type} {
+                &, &:backdrop { // Backdrop button fix: https://github.com/numixproject/numix-gtk-theme/issues/544
+                    @include linear-gradient($bg_color);
 
-        .#{$type} {
-            @include linear-gradient($bg_color);
+                    border: 1px solid shade($bg_color, .8);
+                    caret-color: currentColor;
 
-            border: 1px solid shade($bg_color, .8);
-            color: $fg_color;
+                    label, & { color: $fg_color; }
+                }
 
-            button {
-                @include button($bg_color, $fg_color);
+                button {
+                    @include button($bg_color, $fg_color);
 
-                &.close { @extend %close_button; }
+                    &.close { @extend %close_button; }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/numixproject/numix-gtk-theme/issues/544 Reference code: https://github.com/GNOME/gtk/commit/d74e4af1a2cabb16d851f85a7d40d0de003109e5
Fixed entry selection: https://github.com/GNOME/gtk/commit/ebccc8b23f77ce47ba75a8ea3dda3a32d04d9ab7
Implement entry error and warning code. Reference code: https://github.com/horst3180/arc-theme/blob/master/common/gtk-3.0/3.20/sass/_common.scss#L231

![image](https://cloud.githubusercontent.com/assets/461493/19418808/1e7c7cfa-93cc-11e6-9a92-6f0507771662.png)
![anim](https://cloud.githubusercontent.com/assets/461493/19418813/43c3f402-93cc-11e6-9dcf-c4f3b802b866.gif)
