### PR TITLE
GTK 3.20 :: Add a background to cellrendertext.

### DIFF
--- a/src/gtk-3.20/scss/widgets/_view.scss
+++ b/src/gtk-3.20/scss/widgets/_view.scss
@@ -49,6 +49,13 @@
     }
 
     treeview entry {
+        &:focus {
+            &:dir(rtl), &:dir(ltr) { // specificity bump hack
+                background-color: $base_color;
+                transition-property: color, background;
+            }
+        }
+
         &.flat, & {
             border-radius: 0;
             background-image: none;


### PR DESCRIPTION
Reference code: https://github.com/GNOME/gtk/commit/0d55542359751d80c7ae7bf5b48806e6a9f07a23
