### PR TITLE
GTK 3.20 :: Optimised headerbar and titlebar size

### DIFF
--- a/src/gtk-3.20/scss/widgets/_toolbar.scss
+++ b/src/gtk-3.20/scss/widgets/_toolbar.scss
@@ -96,13 +96,13 @@
         spinbutton,
         separator,
         button { // Size height
-            margin-top: $spacing + 3px;
-            margin-bottom: $spacing + 3px;
+            margin-top: $spacing;
+            margin-bottom: $spacing;
         }
 
         switch { // Size height
-            margin-top: $spacing + 1px;
-            margin-bottom: $spacing + 1px;
+            margin-top: $spacing - 2px;
+            margin-bottom: $spacing - 2px;
         }
 
         window:not(.tiled):not(.maximized) separator:first-child + &, // tackles the paned container case
@@ -118,7 +118,7 @@
         border-radius: $roundness $roundness 0 0;
         color: mix($titlebar_fg_color, $titlebar_bg_color, .1);
         padding: 0 $spacing;
-        min-height: 42px;
+        min-height: 38px;
 
         &:backdrop {
             @include linear-gradient($titlebar_bg_color);


### PR DESCRIPTION
**Gnome-shell:**
![image](https://cloud.githubusercontent.com/assets/461493/19640451/09cc35cc-99dd-11e6-8439-0d43c983c4f1.png)

**Cinnamon:**
![image](https://cloud.githubusercontent.com/assets/461493/19640458/10261834-99dd-11e6-8668-5b9b28472acf.png)

**Ubuntu:**
![image](https://cloud.githubusercontent.com/assets/461493/19640461/1395bf6a-99dd-11e6-9ce0-897f1b16afb9.png)
