### PR TITLE
GTK 3.20 :: Fixed gnome-terminal scrollbar color. Disable backdrop mode.

### DIFF
--- a/src/gtk-3.20/scss/_widgets.scss
+++ b/src/gtk-3.20/scss/_widgets.scss
@@ -37,4 +37,5 @@
 @import "apps/xfce";
 @import "apps/unity";
 @import "apps/lightdm";
+@import "apps/gnome-terminal";
 @import "apps/budgie";

--- a/src/gtk-3.20/scss/apps/_gnome-terminal.scss
+++ b/src/gtk-3.20/scss/apps/_gnome-terminal.scss
@@ -14,10 +14,10 @@
             background-color: $osd_base;
             border-color: border_normal($osd_base);
 
-            &:backdrop {
-                background-color: shade($backdrop_osd_bg, .9);
-                border-color: border_normal(shade($backdrop_osd_bg, .9));
-            }
+            //&:backdrop {
+            //    background-color: shade($backdrop_osd_bg, .9);
+            //    border-color: border_normal(shade($backdrop_osd_bg, .9));
+            //}
         }
 
         scrollbar.vertical {
@@ -28,7 +28,7 @@
 
                 &:hover:active { background-color: $selected_bg_color; }
 
-                &:backdrop { background-color: mix($backdrop_osd_fg, $backdrop_osd_bg, .4); }
+                //&:backdrop { background-color: mix($backdrop_osd_fg, $backdrop_osd_bg, .4); }
 
                 &:disabled { background-color: transparent; }
             }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/461493/19698023/f3cd7d96-9aed-11e6-8170-3531134b5a9b.png)
