### PR TITLE
Added styling to Raven components of Budgie panel

### DIFF
--- a/src/gtk-3.20/scss/_widgets.scss
+++ b/src/gtk-3.20/scss/_widgets.scss
@@ -37,3 +37,4 @@
 @import "apps/xfce";
 @import "apps/unity";
 @import "apps/lightdm";
+@import "apps/budgie";

--- a/src/gtk-3.20/scss/apps/_budgie.scss
+++ b/src/gtk-3.20/scss/apps/_budgie.scss
@@ -1,0 +1,24 @@
+/******************
+ ! Budgie Desktop *
+*******************/
+.budgie-container {
+    background-color: transparent;
+}
+
+.raven {
+    background-color: transparentize($bg_color, .07);
+
+    .raven-header {
+        background-color: $bg_color;
+        border: solid $borders_color;
+        border-width: 1px 0;
+    }
+
+    .raven-background {
+        background-color: transparentize($bg_color, .07);
+    }
+}
+
+.raven-mpris {
+    background-color: transparentize($bg_color, .3);
+}


### PR DESCRIPTION
Fixes #620

New styles are closer to Budgie look, but inherit Numix styling.
Also when opening Raven it had transparent background until opened completely, so that is fixed as well.
Also I'm using darker variant of Dark theme from my fork: https://github.com/nazar-pc/numix-gtk-theme/tree/darker-dark

@ikeydoherty, I'd also like to know what do you think about new look.

| Light before | Light After |
| --- | --- |
| ![light-before](https://cloud.githubusercontent.com/assets/928965/19805889/c7ef1c46-9d1f-11e6-86e9-55e8100dad96.png) | ![light-after](https://cloud.githubusercontent.com/assets/928965/19805951/36b5c062-9d20-11e6-8950-8702cdc4df67.png) |

| Dark before | Dark After |
| --- | --- |
| ![dark-before](https://cloud.githubusercontent.com/assets/928965/19805888/c7eedc54-9d1f-11e6-9f08-813e3b60469e.png) | ![dark-after](https://cloud.githubusercontent.com/assets/928965/19805957/3e318dee-9d20-11e6-9f41-bed64dcecc84.png) |
