### PR TITLE
GTK 3.20 :: No rounded corners for solid-csd.

### DIFF
--- a/src/gtk-3.20/scss/widgets/_toolbar.scss
+++ b/src/gtk-3.20/scss/widgets/_toolbar.scss
@@ -105,10 +105,10 @@
             margin-bottom: $spacing + 1px;
         }
 
-        window:not(.tiled):not(.maximized) separator:first-child + &, // tackles the paned container case
-        window:not(.tiled):not(.maximized) &:first-child { &:backdrop, & { border-top-left-radius: $roundness; } }
+        window:not(.tiled):not(.maximized):not(.solid-csd) separator:first-child + &, // tackles the paned container case
+        window:not(.tiled):not(.maximized):not(.solid-csd) &:first-child { &:backdrop, & { border-top-left-radius: $roundness; } }
 
-        window:not(.tiled):not(.maximized) &:last-child { &:backdrop, & { border-top-right-radius: $roundness; } }
+        window:not(.tiled):not(.maximized):not(.solid-csd) &:last-child { &:backdrop, & { border-top-right-radius: $roundness; } }
     }
 
     %titlebar { // Default headerbar and titlebar code.
@@ -212,7 +212,7 @@
         @extend %titlebar;
     }
 
-    .background:not(.tiled):not(.maximized) .titlebar {
+    .background:not(.tiled):not(.maximized):not(.solid-csd) .titlebar {
         &:backdrop, & {
             border-top-left-radius: $roundness;
             border-top-right-radius: $roundness;


### PR DESCRIPTION
Reference code: https://github.com/GNOME/gtk/commit/da1348edb4efd936af5a893097cac3626b4bb9ac