### PR TITLE
Fix for volume OSD progress bar

### DIFF
--- a/src/gtk-3.20/scss/widgets/_osd.scss
+++ b/src/gtk-3.20/scss/widgets/_osd.scss
@@ -80,9 +80,15 @@
         entry { @include entry($osd_base, $osd_text_color, $osd_borders_color); }
 
         /* used by gnome-settings-daemon's media-keys OSD */
-        trough { background-color: shade($osd_bg, .8); }
+        trough,
+        &.trough {
+            background-color: alpha($osd_fg, .3);
+        }
 
-        progressbar { background-color: $osd_fg; }
+        progressbar,
+        &.progressbar {
+            background-color: $osd_fg;
+        }
 
         // Old GTK 3.0 code
         scale {


### PR DESCRIPTION
| Before | After |
| --- | --- |
|  ![2016-10-31 14-13-57](https://cloud.githubusercontent.com/assets/928965/19875862/26287602-9fd9-11e6-8602-a302a0caf7ee.png) |  ![2016-11-01 02-12-13](https://cloud.githubusercontent.com/assets/928965/19875863/2c83e928-9fd9-11e6-8db0-bebe3a9ebfd1.png) |
| ![2016-10-31 14-14-11](https://cloud.githubusercontent.com/assets/928965/19875864/325d09ba-9fd9-11e6-8071-81ba4cfa1bc2.png) | ![2016-11-01 02-12-38](https://cloud.githubusercontent.com/assets/928965/19875868/37c31110-9fd9-11e6-97ee-3ff73c969881.png) |

Looking more into differences between 3.0 and 3.20 versions I believe some other things might be added as well, here is a diff of the part of _osd from 3.0 and 3.20:
![2016-11-01 02-19-28](https://cloud.githubusercontent.com/assets/928965/19875922/b2529b6c-9fd9-11e6-99d3-677ee07c23fb.png)
`&.slider` makes sense, but plain `slider` doesn't seem to be correct.

Fixes #623