### PR TITLE
Add a missing closing brace in _gnome-applications.scss 

### DIFF
--- a/src/gtk-3.0/scss/apps/_gnome-applications.scss
+++ b/src/gtk-3.0/scss/apps/_gnome-applications.scss
@@ -5,5 +5,5 @@
 @include exports("tilix") {
     .terminal-titlebar {
         border-color: $titlebar_bg_color;
+    }
 }
-


### PR DESCRIPTION
A missing closing `}` prevents building:

```
scss --update --sourcemap=none src/gtk-3.0/scss:src/gtk-3.0/dist
  directory src/gtk-3.0/dist
      error src/gtk-3.0/scss/apps/_gnome-applications.scss (Line 10: Invalid CSS after "}": expected "}", was "")
      error src/gtk-3.0/scss/apps/_gnome-applications.scss (Line 10: Invalid CSS after "}": expected "}", was "")
make: *** [Makefile:17: css] Error 1
```

introduced in 4289b971d67bfbd306e63162fd675545cd4eaa4b