### PR TITLE
Fix issue #77. Correct maximize button behavior in Openbox

### DIFF
--- a/src/openbox-3/themerc
+++ b/src/openbox-3/themerc
@@ -59,6 +59,9 @@ window.active.button.hover.bg: flat solid
 window.active.button.hover.bg.color: #444444
 window.active.button.hover.image.color: #f06860
 
+window.active.button.toggled.image.color: #eeeeee
+window.active.button.toggled.hover.image.color: #f06860
+
 
 # Inactive window
 window.inactive.border.color: #393939
@@ -92,6 +95,9 @@ window.inactive.button.disabled.image.color: #888888
 window.inactive.button.hover.bg: flat solid
 window.inactive.button.hover.bg.color: #444444
 window.inactive.button.hover.image.color: #f06860
+
+window.inactive.button.toggled.image.color: #888888
+window.inactive.button.toggled.hover.image.color: #f06860
 
 
 # OSD


### PR DESCRIPTION
Currently with the Openbox window theme, the maximize button remains red when a window is maximized. I fixed this using the toggle property by adding 2 lines each to the active and inactive sections of the themerc. 

Please see the Openbox theme guide: http://openbox.org/wiki/Help:Themes#window.active.button.toggled.hover.image.color