### PR TITLE
Update xfce4-notifyd specific gtk3 style. Related to #677.

### DIFF
--- a/src/gtk-3.0/scss/apps/_xfce.scss
+++ b/src/gtk-3.0/scss/apps/_xfce.scss
@@ -23,4 +23,17 @@
 
         .menu { -gtk-image-effect: none; }
     }
+
+    #XfceNotifyWindow {
+        background-color: $osd_bg;
+        color: $osd_fg;
+        border-radius: $roundness;
+        border: 1px solid border_normal($osd_bg);
+
+        GtkLabel {
+            &#summary {
+                font-weight: bold;
+            }
+        }
+    }
 }

--- a/src/gtk-3.0/scss/widgets/_osd.scss
+++ b/src/gtk-3.0/scss/widgets/_osd.scss
@@ -128,17 +128,4 @@
             background-image: none;
         }
     }
-
-    #XfceNotifyWindow {
-        background-color: $osd_bg;
-        color: $osd_fg;
-        border-radius: $roundness;
-        border: 1px solid border_normal($osd_bg);
-
-        GtkLabel {
-            &#summary {
-                font-weight: bold;
-            }
-        }
-    }
 }

--- a/src/gtk-3.0/scss/widgets/_osd.scss
+++ b/src/gtk-3.0/scss/widgets/_osd.scss
@@ -8,8 +8,7 @@
 @include exports("osd") {
     GtkOverlay.osd { background-color: transparent; }
 
-    .osd,
-    #XfceNotifyWindow {
+    .osd {
         &.background {
             background-color: alpha($osd_bg, .8);
             color: $osd_fg;
@@ -127,6 +126,19 @@
             border-radius: 0;
             background-color: $selected_bg_color;
             background-image: none;
+        }
+    }
+
+    #XfceNotifyWindow {
+        background-color: $osd_bg;
+        color: $osd_fg;
+        border-radius: $roundness;
+        border: 1px solid border_normal($osd_bg);
+
+        GtkLabel {
+            &#summary {
+                font-weight: bold;
+            }
         }
     }
 }

--- a/src/gtk-3.20/scss/apps/_xfce.scss
+++ b/src/gtk-3.20/scss/apps/_xfce.scss
@@ -27,4 +27,21 @@
             text-shadow: none;
         }
     }
+
+    #XfceNotifyWindow {
+        .osd {
+            background-color: $osd_bg;
+            color: $osd_fg;
+            border-radius: $roundness;
+            border: 1px solid border_normal($osd_bg);
+        }
+
+        &.osd {
+            label {
+                &#summary {
+                    font-weight: bold;
+                }
+            }
+        }
+    }
 }

--- a/src/gtk-3.20/scss/widgets/_osd.scss
+++ b/src/gtk-3.20/scss/widgets/_osd.scss
@@ -263,21 +263,4 @@
             }
         }
     }
-
-    #XfceNotifyWindow {
-        .osd {
-            background-color: $osd_bg;
-            color: $osd_fg;
-            border-radius: $roundness;
-            border: 1px solid border_normal($osd_bg);
-        }
-
-        &.osd {
-            label {
-                &#summary {
-                    font-weight: bold;
-                }
-            }
-        }
-    }
 }

--- a/src/gtk-3.20/scss/widgets/_osd.scss
+++ b/src/gtk-3.20/scss/widgets/_osd.scss
@@ -23,8 +23,7 @@
         }
     }
 
-    button.osd,
-    #XfceNotifyWindow button {
+    button.osd {
         @include button($osd_bg, $osd_fg);
 
         &.image-button {
@@ -73,8 +72,7 @@
         }
     }
 
-    .osd,
-    #XfceNotifyWindow {
+    .osd {
         background-color: $osd_bg;
         color: $osd_fg;
 
@@ -262,6 +260,23 @@
             // OSD vertical
             &.vertical button:first-child {
                 @include button($osd_bg, $osd_fg);
+            }
+        }
+    }
+
+    #XfceNotifyWindow {
+        .osd {
+            background-color: $osd_bg;
+            color: $osd_fg;
+            border-radius: $roundness;
+            border: 1px solid border_normal($osd_bg);
+        }
+
+        &.osd {
+            label {
+                &#summary {
+                    font-weight: bold;
+                }
             }
         }
     }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![xfce-notifyd-before](https://user-images.githubusercontent.com/3535194/39562017-7b5fb9dc-4ed3-11e8-87f5-735ff487d81c.gif) | ![xfce-notifyd-after](https://user-images.githubusercontent.com/3535194/39562034-96a830de-4ed3-11e8-8cd4-8aa52a4322e0.gif) |

Gtk3 styles for xfce4-notifyd had been moved to scss in https://github.com/numixproject/numix-gtk-theme/commit/30b14f77d05389d80b395720e6603836a579edd4. But some styles is not really match to osd styles (border, border-radius) if using Default theme. I found [Default/gtk.css](https://git.xfce.org/apps/xfce4-notifyd/tree/themes/gtk-3.20/Default/gtk.css?h=xfce4-notifyd-0.4.2) defines some _styles_ with low priority that will be used if that _style_ isn't defined in main gtk theme.

I conclude that `#XfceNotifyWindow` selector isn't defined properly. It should be like this [guide](http://docs.xfce.org/apps/notifyd/theming).

I only define styles based on Default/gtk.css, just copying osd styles.

Related to #677.
