### PR TITLE
Update budgie panel and workspace-switcher colors

### DIFF
--- a/src/gtk-3.20/scss/apps/_budgie.scss
+++ b/src/gtk-3.20/scss/apps/_budgie.scss
@@ -24,4 +24,38 @@
     .raven-mpris {
         background-color: transparentize($bg_color, .3);
     }
+
+    .budgie-panel {
+        background-color: $dark_bg_color;
+        color: $dark_fg_color;
+    }
+    
+    .budgie-panel > box > widget > separator {
+        background-color: transparentize($dark_fg_color, .8);
+    }
+    
+    .workspace-switcher {
+        background-color: $dark_bg_color;
+        .workspace-icon-button {
+            background-color: transparent;
+            &:hover {
+                background-color: transparentize($selected_bg_color, .5);
+                border: transparent;
+            }
+        }
+        .workspace-more-label {
+            color: $dark_fg_color;
+        }
+        .workspace-add-button {
+            background-color: transparentize($selected_bg_color, .8);
+            color: $selected_bg_color;
+            border: transparent;
+            &:hover {
+                background-color: transparentize($selected_bg_color, .5);
+            }
+        }
+        .current-workspace {
+            background-color: $selected_bg_color;
+        }
+    }
 }


### PR DESCRIPTION
Update budgie panel and workspace-switcher colors.
Related to #368
There is still a lot to do.
![numix](https://user-images.githubusercontent.com/29115747/46580038-5b996d00-ca0c-11e8-82e8-a7088ed3f780.png)
Left=after, right=before.