### PR TITLE
Replace deprecated Ruby Sass with SassC #734

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SASS=scss
-SASSFLAGS=--sourcemap=none
+SASS=sassc
+SASSFLAGS=-M -t expanded
 GLIB_COMPILE_RESOURCES=glib-compile-resources
 RES_DIR=src/gtk-3.0
 SCSS_DIR=$(RES_DIR)/scss
@@ -14,8 +14,12 @@ UTILS=scripts/utils.sh
 all: clean gresource
 
 css:
-	$(SASS) --update $(SASSFLAGS) $(SCSS_DIR):$(DIST_DIR)
-	$(SASS) --update $(SASSFLAGS) $(SCSS_DIR320):$(DIST_DIR320)
+	mkdir $(DIST_DIR)
+	$(SASS) $(SASSFLAGS) $(SCSS_DIR)/gtk.scss $(DIST_DIR)/gtk.css
+	$(SASS) $(SASSFLAGS) $(SCSS_DIR)/gtk-dark.scss $(DIST_DIR)/gtk-dark.css
+	mkdir $(DIST_DIR320)
+	$(SASS) $(SASSFLAGS) $(SCSS_DIR320)/gtk.scss $(DIST_DIR320)/gtk.css
+	$(SASS) $(SASSFLAGS) $(SCSS_DIR320)/gtk-dark.scss $(DIST_DIR320)/gtk-dark.css
 
 gresource: css
 	$(GLIB_COMPILE_RESOURCES) --sourcedir=$(RES_DIR) $(RES_DIR)/gtk.gresource.xml

--- a/README.md
+++ b/README.md
@@ -16,18 +16,16 @@
 
 First, you need to compile the theme using the [Sass](http://sass-lang.com/) compiler.
 
-To install Sass, install Ruby and the gem command using your distribution's package manager. Then install `sass` with the `gem` command,
-
-`gem install sass` (not needed for Ubuntu/Debian)
+You will need to install SassC (`sassc`) which is likely to be available as a package in your distribution's software repositories.
 
 You'll also need the ```glib-compile-schemas``` and  ```gdk-pixbuf-pixdata``` commands in your path to generate the gresource binary. Install them using your distribution's package manager.
 
 |Distro|Commands|
 |:----:|:----:|
-|![arch][arch] &nbsp;![antergos][antergos]|`sudo pacman -S glib2 gdk-pixbuf2`|
-|![opensuse][opensuse]|`sudo zypper install glib2-devel gdk-pixbuf-devel`|
-|![fedora][fedora]|`sudo dnf install glib2-devel gdk-pixbuf2-devel`|
-|![debian][debian] &nbsp;![ubuntu][ubuntu]|`sudo apt-get install ruby-sass libglib2.0-dev libgdk-pixbuf2.0-dev libxml2-utils`|
+|![arch][arch] &nbsp;![antergos][antergos]|`sudo pacman -S sassc glib2 gdk-pixbuf2`|
+|![opensuse][opensuse]|`sudo zypper install sassc glib2-devel gdk-pixbuf-devel`|
+|![fedora][fedora]|`sudo dnf install sassc glib2-devel gdk-pixbuf2-devel`|
+|![debian][debian] &nbsp;![ubuntu][ubuntu]|`sudo apt-get install sassc libglib2.0-dev libgdk-pixbuf2.0-dev libxml2-utils`|
 
 After installing all the dependencies, change to the cloned directory and, run the following in Terminal,
 

--- a/src/gtk-3.20/scss/apps/_gnome-terminal.scss
+++ b/src/gtk-3.20/scss/apps/_gnome-terminal.scss
@@ -1,5 +1,3 @@
-@import "../widgets/button";
-
 /**********************
  ! Genome Terminal *
 ***********************/

--- a/src/gtk-3.20/scss/apps/_gnome-terminal.scss
+++ b/src/gtk-3.20/scss/apps/_gnome-terminal.scss
@@ -1,4 +1,4 @@
-@import "widgets/button";
+@import "../widgets/button";
 
 /**********************
  ! Genome Terminal *


### PR DESCRIPTION
Ruby Sass reached its end of life as of 2019-03-26 and is no longer supported.

This PR includes the following changes:

- Updates the Makefile to replace Ruby Sass with SassC
- Removes the "widgets/button" import directive from the gtk-3.20 _gnome-terminal.scss file
- Updates the Build It instructions in README.md to use SassC

Fixes #734