### PR TITLE
Eclipse: fix small toolbar buttons

### DIFF
--- a/src/gtk-3.20/scss/_widgets.scss
+++ b/src/gtk-3.20/scss/_widgets.scss
@@ -39,3 +39,4 @@
 @import "apps/lightdm";
 @import "apps/gnome-terminal";
 @import "apps/budgie";
+@import "apps/eclipse";

--- a/src/gtk-3.20/scss/apps/_eclipse.scss
+++ b/src/gtk-3.20/scss/apps/_eclipse.scss
@@ -1,0 +1,9 @@
+/***********
+ ! Eclipse *
+ ***********/
+
+@include exports("eclipse") {
+	button.flat.image-button > image {
+		padding: 3px;
+	}
+}


### PR DESCRIPTION
This fixes an issue where the toolbar buttons of Eclipse were being rendered with a padding of 0. This causes the buttons to be very small and hard to press, while also giving a more cluttered look.

# Before
![before](https://user-images.githubusercontent.com/2057687/97843079-f72f6180-1ce8-11eb-9860-2fe87b13e428.png)

# After
![after](https://user-images.githubusercontent.com/2057687/97843086-fa2a5200-1ce8-11eb-9175-4b58651b5f22.png)