### PR TITLE
Add color for text_view_bg

### DIFF
--- a/src/gtk-3.0/scss/_colors.scss
+++ b/src/gtk-3.0/scss/_colors.scss
@@ -31,6 +31,7 @@
 @define-color success_color #{"" + $success_color};
 @define-color warning_color #{"" + $warning_color};
 @define-color error_color #{"" + $error_color};
+@define-color text_view_bg #{"" + $base_color};
 
 /* widget colors */
 @define-color titlebar_bg_color @dark_bg_color;

--- a/src/gtk-3.20/scss/_colors.scss
+++ b/src/gtk-3.20/scss/_colors.scss
@@ -31,6 +31,7 @@
 @define-color success_color #{"" + $success_color};
 @define-color warning_color #{"" + $warning_color};
 @define-color error_color #{"" + $error_color};
+@define-color text_view_bg #{"" + $base_color};
 
 /* widget colors */
 @define-color titlebar_bg_color @dark_bg_color;


### PR DESCRIPTION
Since <https://gitlab.gnome.org/GNOME/vte/-/commit/a737e397e391761546dd9356ec99f499ccaa4cf8>, VTE requires themes to export text_view_bg, and this commit add it, see `.<https://gitlab.gnome.org/GNOME/vte/-/issues/284>.