### PR TITLE
Fixes #757 error: gtk-dark.css:9381:21: Not using units is deprecated…

### DIFF
--- a/src/gtk-3.0/scss/apps/_thunar.scss
+++ b/src/gtk-3.0/scss/apps/_thunar.scss
@@ -11,7 +11,7 @@
   }
 
   scrolledwindow.shortcuts-pane {
-    border-top-width: 1;
+    border-top-width: 1px;
   }
  }
 }

--- a/src/gtk-3.20/scss/apps/_thunar.scss
+++ b/src/gtk-3.20/scss/apps/_thunar.scss
@@ -11,7 +11,7 @@
   }
 
   scrolledwindow.shortcuts-pane {
-    border-top-width: 1;
+    border-top-width: 1px;
   }
  }
 }


### PR DESCRIPTION
…. Assuming 'px'.